### PR TITLE
Omit 'docs' from url

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -40,6 +40,7 @@ const config = {
       /** @type {import('@docusaurus/preset-classic').Options} */
       ({
         docs: {
+          routeBasePath: '/', // Serve the docs at the site's root
           sidebarPath: require.resolve('./sidebars.js'),
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.


### PR DESCRIPTION
Omit '/docs/' from urls to documentation.

ex. `docs.regression.gg/docs/players/account-setup` -> `docs.regression.gg/players/account-setup`