### PR TITLE
[REG-1197] Use proper DNS record

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -14,7 +14,7 @@ const config = {
   url: 'https://docs.regression.gg',
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
-  baseUrl: '/RegressionDocs/',
+  baseUrl: '/',
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.

--- a/static/CNAME
+++ b/static/CNAME
@@ -1,0 +1,1 @@
+docs.regression.gg


### PR DESCRIPTION
Adds a CNAME record for this site, and re-uses the base path of `/` for proper redirecting. Note that I can't test how this works until we get it into master.