### PR TITLE
[REG-1221] Fix git link

### DIFF
--- a/docs/studios/unity/tutorials/first_tutorial.md
+++ b/docs/studios/unity/tutorials/first_tutorial.md
@@ -47,7 +47,7 @@ the completed tutorial, see the `main` branch.
 Run the following commands in your terminal to start:
 
 ```
-git clone git@github.com:Regression-Games/RGUnitySample.git
+git clone https://github.com/Regression-Games/RGUnitySample.git
 cd RGUnitySample
 git checkout starter
 ```


### PR DESCRIPTION
The current git link for the sample project was using git vs https, which sometimes doesn't work if the user has incorrect SSH keys setup.