### PR TITLE
[REG-1615] Add notes about accessing complex state to doc site

### DIFF
--- a/docs/integrating-with-unity/defining-states.mdx
+++ b/docs/integrating-with-unity/defining-states.mdx
@@ -111,6 +111,27 @@ In addition to the [core](#core-state-properties) state properties, this GameObj
 |-------------|---------------------------|-------------------------------------------------------------------|
 | `KingState` | `RGStateEntity_KingState` | The properties of the KingState MonoBehaviour on this GameObject. |
 
+How to access this state from bot code...
+```cs
+public override void ProcessTick(RG rgObject)
+{
+    // find a my player which has `KingState`
+    var player = rgObject.GetMyPlayer();
+    if (player == null)
+    {
+        return;
+    }
+    
+    // Using non-typed lookups (These do NOT require `using`s specific to your generated code)
+    var nonTypedAccessOfKingState = player.GetField("KingState") as IRGStateEntity;
+    var nonTypedHealthLookup = nonTypedAccessOfKingState?.GetField<int>("Health");
+    
+    // OR...  Using typed lookups (These DO require `using`s specific to your generated code)
+    var typedAccessOfKingState = player.GetFields<RGStateEntity_KingState>().FirstOrDefault();
+    var typedHealthLookup = typedAccessOfKingState?.Health;
+}
+```
+
 Also note that if any Behaviour on a GameObject indicates that `isPlayer` is `true` as this example does, then the [core](#core-state-properties) state for that GameObject will show the value
 of `isPlayer` as `true`.
 
@@ -171,6 +192,27 @@ Note that this property name uses the specified `typeName` from the `[RGStateTyp
 | Name            | Type                      | Description                                                       |
 |-----------------|---------------------------|-------------------------------------------------------------------|
 | `mockPawnState` | `RGStateEntity_PawnState` | The properties of the PawnState MonoBehaviour on this GameObject. |
+
+How to access this state from bot code...
+```cs
+public override void ProcessTick(RG rgObject)
+{
+    // find a my player which has `mockPawnState`
+    var player = rgObject.GetMyPlayer();
+    if (player == null)
+    {
+        return;
+    }
+    
+    // Using non-typed lookups (These do NOT require `using`s specific to your generated code)
+    var nonTypedAccessOfState = player.GetField("mockPawnState") as IRGStateEntity;
+    var nonTypedHealthLookup = nonTypedAccessOfState?.GetField<int>("Health");
+    
+    // OR...  Using typed lookups (These DO require `using`s specific to your generated code)
+    var typedAccessOfState = player.GetFields<RGStateEntity_PawnState>().FirstOrDefault();
+    var typedHealthLookup = typedAccessOfState?.Health;
+}
+```
 
 Also note that if any Behaviour on a GameObject indicates that `isPlayer` is `true` as this example does, then the [core](#core-state-properties) state for that GameObject will show the value
 of `isPlayer` as `true`.
@@ -297,7 +339,26 @@ In addition to the [core](#core-state-properties) state properties, this GameObj
 |-----------------|-------------------------------|-----------------------------------------------------------------------|
 | `WandererState` | `RGStateEntity_WandererState` | The properties of the WandererState MonoBehaviour on this GameObject. |
 
-
+How to access this state from bot code...
+```cs
+public override void ProcessTick(RG rgObject)
+{
+    // find a my player which has `WandererState`
+    var player = rgObject.GetMyPlayer();
+    if (player == null)
+    {
+        return;
+    }
+    
+    // Using non-typed lookups (These do NOT require `using`s specific to your generated code)
+    var nonTypedAccessOfState = player.GetField("WandererState") as IRGStateEntity;
+    var nonTypedCharTypeLookup = nonTypedAccessOfState?.GetField<string>("charType");
+    
+    // OR...  Using typed lookups (These DO require `using`s specific to your generated code)
+    var typedAccessOfState = player.GetFields<RGStateEntity_WandererState>().FirstOrDefault();
+    var typedCharTypeLookup = typedAccessOfState?.charType;
+}
+```
 
 #### `[RGState]` Example 2
 This example shows using `[RGState]` while also using `[RGStateType]`.
@@ -356,6 +417,26 @@ In addition to the [core](#core-state-properties) state properties, this GameObj
 |---------|----------------------------|--------------------------------------------------------------------|
 | `nomad` | `RGStateEntity_NomadState` | The properties of the NomadState MonoBehaviour on this GameObject. |
 
+How to access this state from bot code...
+```cs
+public override void ProcessTick(RG rgObject)
+{
+    // find a my player which has `nomad`
+    var player = rgObject.GetMyPlayer();
+    if (player == null)
+    {
+        return;
+    }
+    
+    // Using non-typed lookups (These do NOT require `using`s specific to your generated code)
+    var nonTypedAccessOfState = player.GetField("nomad") as IRGStateEntity;
+    var nonTypedHealthLookup = nonTypedAccessOfState?.GetField<int>("Health");
+    
+    // OR...  Using typed lookups (These DO require `using`s specific to your generated code)
+    var typedAccessOfState = player.GetFields<RGStateEntity_NomadState>().FirstOrDefault();
+    var typedHealthLookup = typedAccessOfState?.Health;
+}
+```
 
 ### 4 - `RGActionBehaviour` MonoBehaviour
 By adding a Behaviour that extends `RGActionBehaviour` to a GameObject, that GameObject will be included in the state.


### PR DESCRIPTION
Add notes about accessing complex state to doc site

Adds sections like these to each example

![image](https://github.com/Regression-Games/RegressionDocs/assets/112959031/c8d4cefa-12dd-4a6e-bf3d-4c29b78d0878)


---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [ ] The code is extensible and backward compatible
- [ ] New public interfaces are extensible and open to backward compatibility in the future
- [ ] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [ ] Non-critical or potentially modifiable arguments are optional
- [ ] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [ ] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [ ] Functions and classes are documented
- [ ] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
