### PR TITLE
[REG-1635] Add SDK link to homepage

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -25,6 +25,12 @@ const HomepageHeader = () => (
                 Full Reference
               </Link>
             </div>
+            <div style={{marginTop: "16px"}}>
+              Get started immediately by adding the package to Unity:
+              <div style={{marginTop: "16px", fontSize: 12}}>
+                <pre style={{display: "inline"}}>https://github.com/Regression-Games/RGUnityBots.git?path=src/gg.regression.unity.bots#v0.0.16</pre>
+              </div>
+            </div>
           </div>
           <div className="col">
             <img src={require('@site/static/img/demo.gif').default} alt="Regression Games" style={{borderRadius: "12px"}}/>


### PR DESCRIPTION
Adds the SDK url to the homepage for power users who want to jump right in. Assumes they know how to add git packages to Unity through the package manager. 

<img width="1711" alt="Screenshot 2024-03-12 at 12 35 25 PM" src="https://github.com/Regression-Games/RegressionDocs/assets/8053203/c0426d3e-5829-4430-895e-98797ac3c667">

---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [ ] The code is extensible and backward compatible
- [ ] New public interfaces are extensible and open to backward compatibility in the future
- [ ] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [ ] Non-critical or potentially modifiable arguments are optional
- [ ] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [ ] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [ ] Functions and classes are documented
- [ ] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
