### PR TITLE
Updated docs to describe where the saved replays are. (in windows...)

### DIFF
--- a/docs/gameplay-sessions/gameplay-sessions-getting-started.mdx
+++ b/docs/gameplay-sessions/gameplay-sessions-getting-started.mdx
@@ -21,7 +21,7 @@ and run user-defined test scenarios against new data captured during the replay.
 This effectively brings the power of automated testing to the world of game development.
 
 A Gameplay Session can be recorded within Unity either programmatically or through an overlay provided by the SDK.
-The recording is saved locally to your device as you record, and is synced to your Regression Games account when you stop recording.
+The recording is saved locally to your device under `C:\Users\<user_name>\unity_videos\com.unity.multiplayer.samples.coop` as you record, and is synced to your Regression Games account when you stop recording.
 A saved recording can be loaded to reproduce inputs and capture new information from the replay.
 
 ## Strengths of the Gameplay Session system


### PR DESCRIPTION
The [Gameplay Sessions Getting Started Docs](https://docs.regression.gg/gameplay-sessions/gameplay-sessions-getting-started) doesn't tell you where the recordings are saved, this PR adds that information.

![image](https://github.com/user-attachments/assets/39113993-9cd5-425d-a35d-527850a6b8f4)


Where does this get saved in Macs?
---

Find the pull request instructions [here](https://www.notion.so/regressiongg/Pull-Request-Process-0d57a7eb582a446983edfacafa406f1e?pvs=4)

Every reviewer and the owner of the PR should consider these points in their request (feel free to copy this checklist so you can fill it out yourself in the overall PR comment)

- [ ] The code is extensible and backward compatible
- [ ] New public interfaces are extensible and open to backward compatibility in the future
- [ ] If preparing to remove a field in the future (i.e. this PR removes an argument), the argument stays but is no longer functional, and attaches a deprecation warning. A linear task is also created to track this deletion task.
- [ ] Non-critical or potentially modifiable arguments are optional
- [ ] Breaking changes and the approach to handling them have been verified with the team (in the Linear task, design doc, or PR itself)
- [ ] The code is easy to read
- [ ] Unit tests are added for expected and edge cases
- [ ] Integration tests are added for expected and edge cases
- [ ] Functions and classes are documented
- [ ] Migrations for both up and down operations are completed
- [ ] A documentation PR is created and being reviewed for anything in this PR that requires knowledge to use
- [ ] Implications on other dependent code (i.e. sample games and sample bots) is considered, mentioned, and properly handled
- [ ] Style changes and other non-blocking changes are marked as non-blocking from reviewers
